### PR TITLE
DEV-6203: Added meta tag to support utf-8 charset by default in specRunn...

### DIFF
--- a/lib/specRunner.handlebars
+++ b/lib/specRunner.handlebars
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<meta charset="UTF-8">
 <html lang="en">
 <head>
 <link rel="stylesheet" type="text/css" href="{{jasmine_css}}" />


### PR DESCRIPTION
...er.handlebars template used to generate the specRunner.html file
